### PR TITLE
[codex] Update profile README and portfolio

### DIFF
--- a/PORTFOLIO.md
+++ b/PORTFOLIO.md
@@ -1,0 +1,210 @@
+# Thiago Marinho - Public Portfolio
+
+> AI Product Engineer from Brazil. Senior full-stack builder, founder @ iTOP, focused on applied AI, product engineering, and agent-orchestrated delivery.
+>
+> [Website](https://tgmarinhopro.com) | [Projects](https://tgmarinhopro.com/en/projects) | [Blog](https://tgmarinhopro.com/en/blog) | [LinkedIn](https://linkedin.com/in/tgmarinho) | [GitHub](https://github.com/tgmarinho)
+
+---
+
+## Stats at a Glance
+
+| Metric | Signal |
+|---|---|
+| Production experience | 12+ years shipping software |
+| Current role | Founder @ iTOP, AI Product Engineer |
+| Public projects | 20 entries on tgmarinhopro.com/projects |
+| Writing | 100+ blog entries across AI, product engineering, web, mobile, and Web3 |
+| GitHub | 1.1K+ followers |
+| International work | US and Europe clients across healthcare, Web3, and product consulting |
+
+---
+
+## Positioning
+
+My strongest area is applied product engineering: understanding ambiguous user problems, designing the workflow, building the full-stack solution, and shipping it to production.
+
+I am strongest in roles where product, customer context, engineering, and AI sit close together:
+
+- AI Product Engineer
+- Forward-Deployed Engineer
+- Solutions Engineer
+- Founding Engineer
+- Senior/Lead Full-Stack Engineer with product ownership
+
+I use agent orchestration to increase engineering leverage: Conductor workspaces, Cursor, Codex, MCP servers, custom skills, structured specs, and harnesses that coordinate agents to build with speed, discipline, and quality.
+
+---
+
+## Selected Products and Projects
+
+| Project | Year | What it is | Links |
+|---|---:|---|---|
+| iTOP: Inscricoes TOP | 2024 | Multi-tenant event-registration SaaS with payments, QR check-in, WhatsApp flows, terms signature, dashboards, and support workflows. | [source](https://github.com/tgmarinho/itop-lgnd), [demo](https://itop-lgnd-inscricoestop.vercel.app/demo), [live](https://www.inscricoestop.com.br) |
+| tgmarinhopro.com | 2026 | Bilingual personal platform and technical blog built with Next.js, TypeScript, Velite, next-intl, RSS, llms.txt, and AI-native workflows. | [source](https://github.com/tgmarinho/tgmarinho-ai-blog), [live](https://tgmarinhopro.com) |
+| Pi: AI Agent Toolkit | 2026 | Open-source toolkit for building AI coding agents with a TypeScript monorepo, provider APIs, streaming runtime, tools, state, CLI, and reusable UI. | [source](https://github.com/tgmarinho/pi-tg) |
+| Dale Carnegie AI Trainer | 2026 | AI coach that diagnoses situations, maps Dale Carnegie principles, suggests action plans, and supports role-play and reflection. | [source](https://github.com/tgmarinho/dale-carnegie-principles), [live](https://dale-carnegie-principles.vercel.app) |
+| Canetaco | 2026 | Brazilian e-signature SaaS with WhatsApp delivery, Stripe billing, AWS SES, Inngest, and timestamping grounded in Brazilian law. | [source](https://github.com/tgmarinho/canetaco) |
+| 3D Print Management System | 2026 | Internal production system for a 3D printing studio: clients, stock, production queue, payment status, audit log, and realtime sync. | [source](https://github.com/tgmarinho/3d-print-management-system) |
+| Agenda Editor | 2026 | End-to-end custom planner cover editor with Fabric.js, checkout, Pix payments, order tracking, and admin workflows. | [source](https://github.com/tgmarinho/agenda-editor) |
+| Unicrow | 2023 | Web3 escrow platform. Contributed to TypeScript SDK, blockchain indexer, and smart-contract integrations on Ethereum, Arbitrum, and Base. | [source](https://github.com/unicrowio), [live](https://unicrow.io) |
+| Legendarios MS | 2024 | Volunteer-built website for a nonprofit community movement, centralizing events, registrations, photo galleries, and preparation guides. | [live](https://www.legendariosms.com/) |
+
+---
+
+## Production Case Studies
+
+### iTOP
+
+Founded and built a SaaS for event registration and operations. The platform handles registration, payments, QR-code check-in, WhatsApp notifications, terms signature, and operational dashboards.
+
+Evidence:
+
+- 15K+ registrations
+- R$5M+ processed
+- Real events, real payments, real support flows
+- Built and operated with a lean team of three
+
+Stack:
+
+Next.js, TypeScript, tRPC, Prisma, MongoDB, Tailwind, Vercel, Inngest, Asaas, WhatsApp integrations, agent orchestration.
+
+### SwitchCare
+
+Healthcare staffing platform for the US market. I built payroll automation and helped move a fragmented Node + Angular + Flutter stack into a unified TypeScript architecture.
+
+Evidence:
+
+- 10K+ users
+- One-click daily payout flow replacing manual Excel payroll
+- Branch Payments integration with digital wallet creation
+- Shared TypeScript ownership across API, web, and mobile
+
+Stack:
+
+TypeScript, Node.js, React, Next.js, React Native, PostgreSQL, BullMQ, Branch Payments, CI/CD.
+
+### Unicrow
+
+Decentralized escrow product on Arbitrum and Base. I built developer-facing SDK work and a production blockchain indexer that made protocol integration easier for external developers.
+
+Evidence:
+
+- Open-source TypeScript SDK
+- Official protocol integration path
+- Indexer processing thousands of on-chain transactions
+- Smart contract event pipeline into PostgreSQL and GraphQL
+
+Stack:
+
+TypeScript, ethers.js, Ethereum, Arbitrum, Base, Hasura, PostgreSQL, GraphQL, Firestore, Turborepo.
+
+---
+
+## Selected Writing
+
+| Title | Topic | Link |
+|---|---|---|
+| The harness is the product | Coding agents, quality, engineering leverage | [read](https://tgmarinhopro.com/en/blog/the-harness-is-the-product-en) |
+| Conductor: orchestrating multiple AI agents on Mac without the mess | Conductor, worktrees, Codex, parallel agents | [read](https://tgmarinhopro.com/en/blog/conductor-mac-parallel-agents-experience-en) |
+| Agent Harness Engineering in practice | Harness design for coding agents | [read](https://tgmarinhopro.com/en/blog/agent-harness-engineering-in-practice) |
+| Harness Engineering: what makes AI agents ship real software | Context, tools, gates, orchestration | [read](https://tgmarinhopro.com/en/blog/harness-engineering-ai-agents-inscricoes-top) |
+| MCP vs CLI: what each is, when to use them and when not to | MCP, tools, cost, implementation tradeoffs | [read](https://tgmarinhopro.com/en/blog/mcp-vs-cli-when-to-use-each-en) |
+| How to build a GenAI platform: a 7-layer tutorial | RAG, gateway, cache, agents, observability | [read](https://tgmarinhopro.com/en/blog/how-to-build-a-genai-platform-step-by-step-en) |
+| RAG end to end: Input, Retriever, and Generator explained | Retrieval-augmented generation fundamentals | [read](https://tgmarinhopro.com/en/blog/rag-overview-input-retriever-generator-en) |
+| PRD vs SPEC: which one to write first | Product and technical planning in AI-era delivery | [read](https://tgmarinhopro.com/en/blog/prd-vs-spec-with-ai-en) |
+| My AI journey: from ChatGPT in 2023 to the creative chaos of 2026 | AI tooling, workflow evolution, agentic development | [read](https://tgmarinhopro.com/en/blog/my-ai-journey-2023-to-2026-en) |
+| Vibe Coding vs Agentic Engineering | Difference between loose prompting and engineered delivery | [read](https://tgmarinhopro.com/en/blog/vibe-coding-vs-agentic-engineering) |
+
+---
+
+## Open Source and Public Code
+
+| Repository | What it shows |
+|---|---|
+| [itop-lgnd](https://github.com/tgmarinho/itop-lgnd) | Real production SaaS code: events, registrations, payments, dashboards, and operations |
+| [tgmarinho-ai-blog](https://github.com/tgmarinho/tgmarinho-ai-blog) | Next.js 16, React 19, TypeScript, Velite, next-intl, bilingual content, AI-native site workflow |
+| [pi-tg](https://github.com/tgmarinho/pi-tg) | AI agent toolkit and TypeScript monorepo |
+| [README-ecoleta](https://github.com/tgmarinho/README-ecoleta) | README templates used by many developers after Rocketseat content |
+| [gobarber-api-gostack11](https://github.com/tgmarinho/gobarber-api-gostack11) | Node.js, TypeScript, PostgreSQL, Redis, tests, SOLID-style architecture |
+| [members](https://github.com/tgmarinho/members) | Next.js, Apollo, GraphQL, Hasura, Chakra UI |
+| [meetapp](https://github.com/tgmarinho/meetapp) | Full-stack meetup organizer built with React, React Native, Node.js, and Redux |
+
+---
+
+## Technical Writing and Education
+
+- Author of [tgmarinhopro.com](https://tgmarinhopro.com), with long-running technical writing since 2011.
+- Former Dev & Tech Writer at Rocketseat.
+- Published technical content across JavaScript, React, Node.js, TypeScript, mobile, Web3, AI agents, RAG, and software engineering.
+- Public writing is part of the work: explain the decision, show the implementation, publish the learning.
+
+---
+
+## Proof Links
+
+| Link | Why it matters |
+|---|---|
+| [iTOP production site](https://www.inscricoestop.com.br) | Real product with users and payments |
+| [iTOP source code](https://github.com/tgmarinho/itop-lgnd) | Production architecture, code, commits, and technical decisions |
+| [iTOP demo](https://itop-lgnd-inscricoestop.vercel.app/demo) | Recruiters and hiring managers can inspect the product quickly |
+| [Intro video](https://www.youtube.com/watch?v=WRBbOs7l2LU) | English communication and senior engineering pitch |
+| [Projects page](https://tgmarinhopro.com/en/projects) | Full public list of products, tools, experiments, and open-source work |
+| [Blog archive](https://tgmarinhopro.com/en/blog) | Public writing archive across AI, product engineering, and software craft |
+
+---
+
+## Stack
+
+**Languages**
+
+TypeScript, JavaScript, SQL, GraphQL
+
+**Frontend and mobile**
+
+Next.js, React, React Native, Tailwind, shadcn/ui, Vite
+
+**Backend and data**
+
+Node.js, tRPC, REST, GraphQL, Prisma, PostgreSQL, MongoDB, Hasura, Redis, BullMQ, Inngest
+
+**AI and agentic workflows**
+
+Codex, Cursor, Conductor, MCP, custom skills, structured specs, harness engineering, RAG, tool use, Vercel AI SDK, OpenAI API, Anthropic SDK
+
+**Infrastructure and delivery**
+
+Vercel, AWS, Docker, Firebase, Sentry, CI/CD, Turborepo
+
+**Web3**
+
+ethers.js, Ethereum, Arbitrum, Base, WAX, smart-contract integrations, NFT marketplace flows
+
+---
+
+## Career Timeline
+
+| Period | Role | Highlights |
+|---|---|---|
+| 2024 - Present | Founder @ iTOP | Built and operate event-registration SaaS with payments, check-in, WhatsApp, dashboards, and AI-first workflows |
+| 2021 - 2026 | Senior Software Engineer @ Popstand | International consulting across healthcare, Web3, NFT marketplaces, and product delivery |
+| 2023 - 2025 | SwitchCare | Healthcare staffing platform, payroll automation, Branch Payments, TypeScript architecture |
+| 2021 - 2023 | Unicrow | Web3 escrow SDK, blockchain indexer, frontend, smart-contract integrations |
+| 2020 - 2021 | Dev & Tech Writer @ Rocketseat | Technical content for the Brazilian JavaScript ecosystem |
+| 2018 - 2020 | Freelancer | Websites and production web apps with JavaScript, React, Meteor, GraphQL, and MongoDB |
+| 2017 | Full-Stack Java Developer @ Projeta Facil | Budgeting system for civil engineers using Java, Spring, Thymeleaf, MySQL, and AWS EC2 |
+| 2014 - 2021 | IT Technician @ UFGD | Infrastructure support, institutional systems, and distance learning tutoring |
+| 2012 - 2014 | Java Developer @ AZ Informatica | Administrative management systems with Java, JSF, Hibernate, JPA, Oracle, and SQL Server |
+| 2011 - 2012 | Java Developer @ Dataprev | Real-time server monitoring system using Java EE, Hibernate/JPA, JSF, iReport, and JFreeCharts |
+
+---
+
+## Education
+
+- Graduate degree in Software Engineering, Estacio, 2013-2016.
+- Bachelor's degree in Computer Science, Uniderp, 2009-2012.
+
+---
+
+## Last Updated
+
+July 2026

--- a/README.md
+++ b/README.md
@@ -1,58 +1,133 @@
+<h1 align="center">Hi, I'm Thiago Marinho 👋</h1>
 
- <h3> Thiago Marinho 💻 </h3>
- <h4>AI Product Engineer | 10+ Years Full-Stack Developer | Building AI-Powered Products | TypeScript, React, React Native, Node.js | LLMs, RAG, AI Agents</h4>
-   
- <p align="left" style="background:yellow">
-      <a href="https://codepen.io/tgmarinho" target="_blank">
-        <img align="center" src="https://img.shields.io/badge/-tgmarinho-05122A?style=flat&logo=codepen" alt="codepen"/>
-      </a>
-      <a href="https://twitter.com/tgmarinho" target="_blank">
-        <img align="center" src="https://img.shields.io/badge/-tgmarinho-05122A?style=flat&logo=twitter" alt="twitter"/>  
-      </a>
-      <a href="https://linkedin.com/in/tgmarinho" target="_blank">
-        <img align="center" src="https://img.shields.io/badge/-tgmarinho-05122A?style=flat&logo=linkedin" alt="linkedin"/>
-      </a>
-      <a href="https://instagram.com/tgmarinho" target="_blank">
-      <img align="center" src="https://img.shields.io/badge/-tgmarinho-05122A?style=flat&logo=instagram" alt="instagram"/>
-      </a>
-      <a href="https://youtube.com/tgmarinho" target="_blank">
-      <img align="center" src="https://img.shields.io/badge/-tgmarinho-05122A?style=flat&logo=youtube" alt="youtube"/>
-      </a>
-  </p>
-      </a>
- 
-👋🏻 AI Product Engineer | Full-Stack Engineer → AI
+<p align="center">
+  <b>AI Product Engineer</b> · Senior Full-Stack Builder · Founder @ iTOP
+  <br>
+  <i>I turn ambiguous user pain into shipped software, using AI as leverage.</i>
+</p>
 
-I build products from zero to production, focused on intelligent automations powered by AI Agents and RAG.
+<p align="center">
+  <a href="https://tgmarinhopro.com"><img src="https://img.shields.io/badge/Website-111827?style=flat-square&logo=vercel&logoColor=white" alt="Website"></a>
+  <a href="https://github.com/tgmarinho"><img src="https://img.shields.io/badge/GitHub-181717?style=flat-square&logo=github&logoColor=white" alt="GitHub"></a>
+  <a href="https://linkedin.com/in/tgmarinho"><img src="https://img.shields.io/badge/LinkedIn-0A66C2?style=flat-square&logo=linkedin&logoColor=white" alt="LinkedIn"></a>
+  <a href="https://twitter.com/tgmarinho"><img src="https://img.shields.io/badge/X-000000?style=flat-square&logo=x&logoColor=white" alt="X"></a>
+  <a href="https://youtube.com/tgmarinho"><img src="https://img.shields.io/badge/YouTube-FF0000?style=flat-square&logo=youtube&logoColor=white" alt="YouTube"></a>
+  <a href="./PORTFOLIO.md"><img src="https://img.shields.io/badge/Full_Portfolio-1F2937?style=flat-square" alt="Full portfolio"></a>
+</p>
 
-I bring 10+ years of experience building production systems across industries such as healthcare, Web3, NFT marketplaces, government administrative systems, and event platforms. I take end-to-end ownership — from product vision to architecture and deployment.
+---
 
-Today, I use AI tools daily to accelerate my development workflow, ship faster, and maintain high code quality — with strong focus on priority management, task organization, product thinking, and user experience. My work is centered on building intelligent applications and exploring how LLMs can fundamentally improve real user experiences.
+### About me
 
-What I’ve built
+I'm an AI Product Engineer from Brazil with 12+ years building production systems across healthcare, fintech, Web3, event platforms, and administrative systems.
 
-→ A TypeScript SDK for Escrow process
-→ Blockchain indexers processing thousands of transactions in real time
-→ A healthcare platform serving thousands of users with multiple roles (API, web, mobile)
-→ NFT marketplaces on Ethereum and WAX
+My strongest area is applied product engineering: understanding ambiguous user problems, designing the workflow, building the full-stack solution, and shipping it to production. I am not trying to be a low-level ML researcher. I use modern engineering and AI tools to solve real business problems end to end.
 
-My stack
+Today I work through agent orchestration: Conductor workspaces, Cursor, Codex, MCP servers, custom skills, structured specs, and harnesses that coordinate agents to build with speed, engineering discipline, and quality. The goal is not to make demos. The goal is to ship software that keeps working after real users show up.
 
-TypeScript • React • React Native • Next.js • Node.js • PostgreSQL • MongoDB
+- 🔭 Working on: AI-powered SaaS, agentic workflows, RAG systems, and full-stack products
+- 💬 Ask me about: TypeScript, Next.js, React, React Native, Node.js, PostgreSQL, MongoDB, Web3, product engineering, and agent-orchestrated development
+- 🌍 Open to: AI Product Engineer, Forward-Deployed Engineer, Solutions Engineer, Founding Engineer, and Senior/Lead Full-Stack roles
 
-Focus on AI
+<p align="center">
+  <img src="https://img.shields.io/badge/12%2B_years-Production_software-2563EB?style=flat-square" alt="12+ years production software">
+  <img src="https://img.shields.io/badge/Founder-iTOP-059669?style=flat-square" alt="Founder iTOP">
+  <img src="https://img.shields.io/badge/Focus-Applied_AI-7C3AED?style=flat-square" alt="Applied AI">
+  <img src="https://img.shields.io/badge/Remote-Global-111827?style=flat-square" alt="Global remote">
+</p>
 
-→ LLM integration & Prompt Engineering
-→ RAG systems & vector databases
-→ AI Agents & automation
-→ AI-powered product features
+---
 
-Why I can help with AI
+### Selected work
 
-Many AI enthusiasts can build impressive prototypes, but struggle to take them to production, scale them, and keep them running. I bring 10 years of experience shipping, scaling, and maintaining real-world products, now applied directly to AI-driven applications.
+| Product / project | What I did | Proof |
+|---|---|---|
+| [iTOP](https://www.inscricoestop.com.br) | Founded and built a multi-tenant event-registration SaaS with payments, QR check-in, WhatsApp flows, terms signature, analytics, and AI-first support workflows. | 15K+ registrations, R$5M+ processed, lean team of three |
+| SwitchCare | Built payroll automation for a US healthcare staffing platform and led the move from Node + Angular + Flutter to a unified TypeScript stack. | 10K+ users, one-click daily payouts replacing manual Excel payroll |
+| [Unicrow SDK](https://github.com/unicrowio/sdk) | Built the official TypeScript SDK and production indexer for a decentralized escrow protocol on Arbitrum and Base. | Open-source SDK, thousands of on-chain transactions indexed |
+| WAX NFT / OnGaia | Built Web3 marketplace features, minting flows, auctions, real-time status UI, media optimization, and live-streaming sales. | Production NFT marketplace work across WAX and EVM ecosystems |
+| [tgmarinhopro.com](https://tgmarinhopro.com) | Maintain a personal technical blog and portfolio where I document what I build and learn. | 14+ years writing, 100+ public blog entries |
 
-🔗 tgmarinhopro.com
-💻 github.com/tgmarinho
-🌍 Open to opportunities as an AI Product Engineer or Full-Stack AI Engineer — global remote
-  
-  🚀 😃
+<sub>More projects, writing, public code, and proof links in the [full portfolio](./PORTFOLIO.md).</sub>
+
+---
+
+### How I work
+
+- **Customer-first engineering**: start from the pain, not the framework.
+- **Spec-driven execution**: turn discovery into clear specs, workflows, and acceptance criteria.
+- **Agent-orchestrated delivery**: use Conductor, Cursor, Codex, MCP, custom skills, and harnesses to coordinate agents, engineer solutions, and ship faster with quality.
+- **Full-stack ownership**: architecture, frontend, backend, mobile, data, payments, deployment, and production support.
+- **Pragmatic product sense**: ship the useful version, measure what changed, and improve from real usage.
+
+---
+
+### AI focus
+
+- LLM integration in real products
+- RAG pipelines and grounded assistant experiences
+- Tool use, MCP, and agentic workflows
+- Evaluation loops, guardrails, and observability
+- AI-first internal tools and support automation
+- Harness engineering for reliable agent-orchestrated development
+
+---
+
+### Tech stack
+
+**Product engineering**
+
+![TypeScript](https://img.shields.io/badge/TypeScript-3178C6?style=flat-square&logo=typescript&logoColor=white)
+![Next.js](https://img.shields.io/badge/Next.js-000000?style=flat-square&logo=nextdotjs&logoColor=white)
+![React](https://img.shields.io/badge/React-149ECA?style=flat-square&logo=react&logoColor=white)
+![React Native](https://img.shields.io/badge/React_Native-149ECA?style=flat-square&logo=react&logoColor=white)
+![Node.js](https://img.shields.io/badge/Node.js-339933?style=flat-square&logo=nodedotjs&logoColor=white)
+![tRPC](https://img.shields.io/badge/tRPC-2596BE?style=flat-square&logo=trpc&logoColor=white)
+![GraphQL](https://img.shields.io/badge/GraphQL-E10098?style=flat-square&logo=graphql&logoColor=white)
+
+**Data, infra, and AI**
+
+![PostgreSQL](https://img.shields.io/badge/PostgreSQL-4169E1?style=flat-square&logo=postgresql&logoColor=white)
+![MongoDB](https://img.shields.io/badge/MongoDB-47A248?style=flat-square&logo=mongodb&logoColor=white)
+![Prisma](https://img.shields.io/badge/Prisma-2D3748?style=flat-square&logo=prisma&logoColor=white)
+![Vercel](https://img.shields.io/badge/Vercel-000000?style=flat-square&logo=vercel&logoColor=white)
+![OpenAI](https://img.shields.io/badge/OpenAI-111827?style=flat-square&logo=openai&logoColor=white)
+![Anthropic](https://img.shields.io/badge/Anthropic-191919?style=flat-square&logo=anthropic&logoColor=white)
+![MCP](https://img.shields.io/badge/MCP-7C3AED?style=flat-square)
+![RAG](https://img.shields.io/badge/RAG-2563EB?style=flat-square)
+
+**Web3**
+
+![Ethereum](https://img.shields.io/badge/Ethereum-3C3C3D?style=flat-square&logo=ethereum&logoColor=white)
+![ethers.js](https://img.shields.io/badge/ethers.js-2535A0?style=flat-square)
+![Arbitrum](https://img.shields.io/badge/Arbitrum-28A0F0?style=flat-square&logo=arbitrum&logoColor=white)
+![Base](https://img.shields.io/badge/Base-0052FF?style=flat-square&logo=coinbase&logoColor=white)
+
+---
+
+### Career throughline
+
+I have worked across support, government systems, freelancing, technical writing, international consulting, Web3, healthcare, and now my own SaaS product.
+
+The pattern is consistent: I enter messy operational context, understand the people and constraints, design the system, write the code, and ship something useful.
+
+---
+
+### GitHub activity
+
+<p align="center">
+  <img src="https://github-readme-stats.vercel.app/api?username=tgmarinho&show_icons=true&hide_border=true&theme=transparent" alt="Thiago Marinho GitHub stats">
+  <img src="https://github-readme-stats.vercel.app/api/top-langs/?username=tgmarinho&layout=compact&hide_border=true&theme=transparent" alt="Thiago Marinho top languages">
+</p>
+
+<p align="center">
+  <img src="./github-contribution-grid-snake.svg" alt="GitHub contribution snake animation">
+</p>
+
+---
+
+### Let's connect
+
+I am interested in AI product engineering, applied AI, developer tools, and product-led teams where customer context sits close to engineering.
+
+🔗 [tgmarinhopro.com](https://tgmarinhopro.com) · 💻 [github.com/tgmarinho](https://github.com/tgmarinho) · 💼 [linkedin.com/in/tgmarinho](https://linkedin.com/in/tgmarinho)


### PR DESCRIPTION
Updates the profile README into a stronger AI Product Engineer landing page inspired by the lusoal/lusoal structure.

Adds a new PORTFOLIO.md with selected projects, production case studies, writing, proof links, stack, career timeline, and education.

The README now links to the full portfolio and reflects the current agent-orchestrated workflow with Conductor, Cursor, Codex, MCP, skills, and harnesses.

Validation: reviewed the diff against origin/main, checked the relevant Markdown text for stale Claude Code or AI-assisted wording, and verified key public links returned HTTP 200.