### PR TITLE
Fix GitHub profile metrics sections

### DIFF
--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -1,34 +1,39 @@
-name: GitHub Metrics
+name: GitHub metrics
 
 on:
   schedule:
-    - cron: "0 9 * * *"
+    - cron: "0 9 * * *" # daily
   workflow_dispatch:
   push:
-    branches:
-      - main
+    branches: [main]
 
 permissions:
   contents: write
 
 jobs:
-  github-metrics:
+  metrics:
     runs-on: ubuntu-latest
     steps:
-      - uses: lowlighter/metrics@latest
+      - name: Overview panel
+        uses: lowlighter/metrics@latest
         with:
-          filename: github-stats.svg
           token: ${{ secrets.METRICS_TOKEN }}
           user: tgmarinho
+          filename: github-metrics.svg
           template: classic
           base: header, activity, community, repositories, metadata
           config_timezone: America/Campo_Grande
-          plugin_repositories: yes
-          plugin_repositories_featured: >-
-            tgmarinho/itop-lgnd,
-            tgmarinho/tgmarinho-ai-blog,
-            tgmarinho/pi-tg,
-            tgmarinho/canetaco,
-            tgmarinho/agenda-editor,
-            tgmarinho/dale-carnegie-principles
-          plugin_repositories_order: featured
+          committer_message: "chore: refresh GitHub metrics"
+
+      - name: Languages panel
+        uses: lowlighter/metrics@latest
+        with:
+          token: ${{ secrets.METRICS_TOKEN }}
+          user: tgmarinho
+          filename: github-metrics-languages.svg
+          base: ""
+          plugin_languages: yes
+          plugin_languages_details: bytes-size, percentage
+          plugin_languages_limit: 8
+          config_timezone: America/Campo_Grande
+          committer_message: "chore: refresh GitHub metrics (languages)"

--- a/README.md
+++ b/README.md
@@ -56,11 +56,25 @@ Today I work through agent orchestration: Claude Code, Cursor, Codex, custom ski
 
 ### 📦 Featured repositories
 
+| Repository | Stars | What it is |
+|---|---|---|
+| [itop-lgnd](https://github.com/tgmarinho/itop-lgnd) | ![stars](https://img.shields.io/github/stars/tgmarinho/itop-lgnd?style=flat-square&label=%E2%98%85&color=2563EB) | Full-stack SaaS for large-scale events: registration, payments, check-in, and analytics |
+| [tgmarinho-ai-blog](https://github.com/tgmarinho/tgmarinho-ai-blog) | ![stars](https://img.shields.io/github/stars/tgmarinho/tgmarinho-ai-blog?style=flat-square&label=%E2%98%85&color=2563EB) | Bilingual personal website and technical blog built with Next.js, TypeScript, and Velite |
+| [pi-tg](https://github.com/tgmarinho/pi-tg) | ![stars](https://img.shields.io/github/stars/tgmarinho/pi-tg?style=flat-square&label=%E2%98%85&color=2563EB) | Open-source AI coding agent toolkit and TypeScript monorepo |
+| [canetaco](https://github.com/tgmarinho/canetaco) | ![stars](https://img.shields.io/github/stars/tgmarinho/canetaco?style=flat-square&label=%E2%98%85&color=2563EB) | Brazilian electronic signature SaaS with WhatsApp workflows |
+
+<sub>More repositories and proof links in the [full portfolio](./PORTFOLIO.md).</sub>
+
+---
+
+### 📊 GitHub stats
+
 <p align="center">
-  <a href="https://github.com/lowlighter/metrics">
-    <img src="/github-stats.svg" alt="Featured repositories and GitHub metrics" width="100%">
-  </a>
+  <img src="./github-metrics.svg" alt="GitHub metrics">
+  <img src="./github-metrics-languages.svg" alt="Top languages">
 </p>
+
+<sub>Auto-generated daily by <a href="https://github.com/lowlighter/metrics">lowlighter/metrics</a> — static SVG, no flaky third-party calls.</sub>
 
 ---
 


### PR DESCRIPTION
## Summary

Updates the profile README to match the referenced implementation: featured repositories are now a Markdown table with Shields star badges, and GitHub stats live in a separate section. The metrics workflow now generates `github-metrics.svg` and `github-metrics-languages.svg` via lowlighter/metrics instead of the missing `github-stats.svg`. This fixes the broken profile image root cause and keeps stats as static SVGs refreshed by GitHub Actions.

## Validation

Ran `git diff --check` and parsed `.github/workflows/metrics.yml` with Ruby YAML.